### PR TITLE
Add S3&K from SEGA Mega Drive & Genesis Classics.

### DIFF
--- a/src/BizHawk.Client.EmuHawk/_shuffletriggers/SONIC KNUCKLES WSONIC3 GEN.txt
+++ b/src/BizHawk.Client.EmuHawk/_shuffletriggers/SONIC KNUCKLES WSONIC3 GEN.txt
@@ -1,0 +1,1 @@
+rings>bytes:FE21/base:256/minChange:0/maxChange:2147483647/delay:0/domain:DEFAULT/controlOutput:PRESS/enabled:True/isTracker:False/trackerDivisor:1/blockFromZero:False/steppedChangeEventBuffer:0


### PR DESCRIPTION
This ROM has a different reported name than the existing S3&K template.
It should be added as the Mega Drive & Genesis Classics bundle is one of the most accessible ways to legally get the ROM.